### PR TITLE
Bug in creating reference pointcloud for ICP registration

### DIFF
--- a/src/laserPosegraphOptimization.cpp
+++ b/src/laserPosegraphOptimization.cpp
@@ -468,7 +468,7 @@ pcl::PointCloud<PointType>::Ptr transformPointCloud(pcl::PointCloud<PointType>::
     return cloudOut;
 } // transformPointCloud
 
-void loopFindNearKeyframesCloud( pcl::PointCloud<PointType>::Ptr& nearKeyframes, const int& key, const int& submap_size, const int& root_idx)
+void loopFindNearKeyframesCloud( pcl::PointCloud<PointType>::Ptr& nearKeyframes, const int& key, const int& submap_size)
 {
     // extract and stacking near keyframes (in global coord)
     nearKeyframes->clear();
@@ -499,8 +499,8 @@ std::optional<gtsam::Pose3> doICPVirtualRelative( int _loop_kf_idx, int _curr_kf
     int historyKeyframeSearchNum = 25; // enough. ex. [-25, 25] covers submap length of 50x1 = 50m if every kf gap is 1m
     pcl::PointCloud<PointType>::Ptr cureKeyframeCloud(new pcl::PointCloud<PointType>());
     pcl::PointCloud<PointType>::Ptr targetKeyframeCloud(new pcl::PointCloud<PointType>());
-    loopFindNearKeyframesCloud(cureKeyframeCloud, _curr_kf_idx, 0, _loop_kf_idx); // use same root of loop kf idx 
-    loopFindNearKeyframesCloud(targetKeyframeCloud, _loop_kf_idx, historyKeyframeSearchNum, _loop_kf_idx); 
+    loopFindNearKeyframesCloud(cureKeyframeCloud, _curr_kf_idx, 0); // use same root of loop kf idx 
+    loopFindNearKeyframesCloud(targetKeyframeCloud, _loop_kf_idx, historyKeyframeSearchNum); 
 
     // loop verification 
     sensor_msgs::PointCloud2 cureKeyframeCloudMsg;

--- a/src/laserPosegraphOptimization.cpp
+++ b/src/laserPosegraphOptimization.cpp
@@ -478,7 +478,7 @@ void loopFindNearKeyframesCloud( pcl::PointCloud<PointType>::Ptr& nearKeyframes,
             continue;
 
         mKF.lock(); 
-        *nearKeyframes += * local2global(keyframeLaserClouds[keyNear], keyframePosesUpdated[root_idx]);
+        *nearKeyframes += * local2global(keyframeLaserClouds[keyNear], keyframePosesUpdated[keyNear]);
         mKF.unlock(); 
     }
 


### PR DESCRIPTION
This bug has been already highlighted and well explained in these two links. https://github.com/gisbi-kim/SC-A-LOAM/issues/11
https://github.com/gisbi-kim/SC-A-LOAM/issues/12
To check this - one can visualize the loop submap in RVIZ and can see the cluttered point cloud as it does not have correct registration.